### PR TITLE
Add product shipping functionality to ReverbAccess

### DIFF
--- a/src/ReverbAccess/IReverbOrdersService.cs
+++ b/src/ReverbAccess/IReverbOrdersService.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using ReverbAccess.Models.Product;
 using System;
 using ReverbAccess.Models.Order;
+using ReverbAccess.Models.Shipping;
 
 namespace ReverbAccess
 {
@@ -10,6 +11,7 @@ namespace ReverbAccess
 	{
 		IEnumerable<ReverbOrderEntity> GetOrders(DateTime dateFrom, DateTime dateTo);
 		Task<IEnumerable<ReverbOrderEntity>> GetOrdersAsync(DateTime dateFrom, DateTime dateTo);
+		String ShipOrder(String orderNumber, ReverbShippingEntity shippingEntity);
 
 		Boolean IsOrdersReceived();
 		Task<Boolean> IsOrdersReceivedAsync();

--- a/src/ReverbAccess/Models/Command/ReverbCommand.cs
+++ b/src/ReverbAccess/Models/Command/ReverbCommand.cs
@@ -6,6 +6,7 @@
 		public static readonly ReverbCommand GetToken = new ReverbCommand("/api/auth/email");
 
 		public static readonly ReverbCommand GetProducts = new ReverbCommand("/api/my/listings.json");
+		public static readonly ReverbCommand GetProductsBySKU = new ReverbCommand("/api/my/listings");
 		public static readonly ReverbCommand GetProductsDrafts = new ReverbCommand("/api/my/listings/drafts");
 		public static readonly ReverbCommand GetProductsById = new ReverbCommand("/api/listings/{0}");
 		public static readonly ReverbCommand UpdateProduct = new ReverbCommand("/api/listings/{0}");
@@ -17,6 +18,8 @@
 
 		public static readonly ReverbCommand GetOrdersSellingAwaitingShipment =
 			new ReverbCommand("/api/my/orders/selling/awaiting_shipment");
+
+		public static readonly ReverbCommand ShipOrdersByID = new ReverbCommand("/api/my/orders/selling");
 
 		private ReverbCommand(string command)
 		{

--- a/src/ReverbAccess/Models/Error/ReverbErrorData.cs
+++ b/src/ReverbAccess/Models/Error/ReverbErrorData.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ReverbAccess.Models.Error {
+    public class ReverbErrorData {
+        public string message { get; set; }
+    }
+}

--- a/src/ReverbAccess/Models/Product/ReverbProduct.cs
+++ b/src/ReverbAccess/Models/Product/ReverbProduct.cs
@@ -45,6 +45,7 @@ namespace ReverbAccess.Models.Product
 		public ReverbProductItemLinks _links { get; set; }
 
 		public ReverbProductItemShipping shipping { get; set; }
+		public bool has_inventory { get; set; }
 
 		public Int32 inventory { get; set; }
 

--- a/src/ReverbAccess/Models/Product/ReverbProductEntity.cs
+++ b/src/ReverbAccess/Models/Product/ReverbProductEntity.cs
@@ -16,5 +16,7 @@ namespace ReverbAccess.Models.Product
 		public string Sku { get; set; }
 
 		public string Slug { get; set; }
+
+		public ReverbPrice Price { get; set; }
 	}
 }

--- a/src/ReverbAccess/Models/Product/ReverbProductParam.cs
+++ b/src/ReverbAccess/Models/Product/ReverbProductParam.cs
@@ -21,5 +21,7 @@ namespace ReverbAccess.Models.Product
 
 		[DataMember(Name = "slug")]
 		public string Slug { get; set; }
+		[DataMember(Name = "price")]
+		public ReverbPrice Price { get; set; }
 	}
 }

--- a/src/ReverbAccess/Models/Shipping/ReverbShippingEntity.cs
+++ b/src/ReverbAccess/Models/Shipping/ReverbShippingEntity.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ReverbAccess.Models.Shipping {
+    public class ReverbShippingEntity {
+        public String provider { get; set; }
+        public String tracking_number { get; set; }
+        public bool send_notification { get; set; }
+    }
+}

--- a/src/ReverbAccess/ReverbAccess.csproj
+++ b/src/ReverbAccess/ReverbAccess.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Helpers\IdHelper.cs" />
     <Compile Include="Models\Auth\UserKeyToken.cs" />
     <Compile Include="Models\Auth\UserKeyType.cs" />
+    <Compile Include="Models\Error\ReverbErrorData.cs" />
     <Compile Include="Models\Order\ReverbOrderEntity.cs" />
     <Compile Include="Models\Order\ReverbOrderStatusEnum.cs" />
     <Compile Include="Models\Product\ReverbProductEntity.cs" />
@@ -71,6 +72,7 @@
     <Compile Include="Models\ReverbLinks.cs" />
     <Compile Include="Models\ReverbLocation.cs" />
     <Compile Include="Models\ReverbPrice.cs" />
+    <Compile Include="Models\Shipping\ReverbShippingEntity.cs" />
     <Compile Include="ReverbFactory.cs" />
     <Compile Include="ReverbProductsService.cs" />
     <Compile Include="ReverbOrdersService.cs" />

--- a/src/ReverbAccess/ReverbOrdersService.cs
+++ b/src/ReverbAccess/ReverbOrdersService.cs
@@ -8,6 +8,8 @@ using ReverbAccess.Services;
 using CuttingEdge.Conditions;
 using System;
 using ReverbAccess.Models.Order;
+using ReverbAccess.Models.Shipping;
+using ServiceStack;
 
 namespace ReverbAccess
 {
@@ -415,6 +417,16 @@ namespace ReverbAccess
 			});
 
 			return data;
+		}
+
+		public string ShipOrder(string orderNumber, ReverbShippingEntity shippingEntity) {
+			var endpoint = ParamsBuilder.ShipOrdersParams(orderNumber);
+			var jsonContent = shippingEntity.ToJson();
+			var returnedVal = String.Empty;
+			ActionPolicies.Submit.Do(() => {
+				returnedVal = _webRequestServices.PostData(ReverbCommand.ShipOrdersByID, endpoint, jsonContent);
+			});
+			return returnedVal;
 		}
 	}
 }

--- a/src/ReverbAccess/Services/ParamsBuilder.cs
+++ b/src/ReverbAccess/Services/ParamsBuilder.cs
@@ -45,6 +45,11 @@ namespace ReverbAccess.Services
 			return endpoint;
 		}
 
+		public static string ShipOrdersParams(string orderNumber) {
+			var endpoint = string.Format("/{0}/ship", orderNumber);
+			return endpoint;
+		}
+
 		public static string CreateProductsParams(String state)
 		{
 			var endpoint = string.Format("?{0}={1}",


### PR DESCRIPTION
Adds the ability to ship products via Reverb's API from ReverbAccess.
Also provides an error model to allow easier parsing of errors back from the API.